### PR TITLE
chore: update ldflags to use correct version path

### DIFF
--- a/.goreleaser-alauda.yml
+++ b/.goreleaser-alauda.yml
@@ -27,7 +27,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -w -s -X knative.dev/pkg/changeset.rev={{.Version}}
+      - -w -s -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion={{.Version}}
     main: ./cmd/tkn
     binary: alauda-tkn
 
@@ -57,6 +57,6 @@ release:
 
     ---
 
-    This release is intended for use only as part of the Alauda product suite. 
-    It is not recommended for use by individuals or teams outside of Alauda. 
+    This release is intended for use only as part of the Alauda product suite.
+    It is not recommended for use by individuals or teams outside of Alauda.
     Any consequences arising from its use are the sole responsibility of the user.


### PR DESCRIPTION
Update goreleaser configuration to use the correct version path for CLI binary.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Run the code checkers with `make check`
- [ ] Regenerate the manpages, docs and go formatting with `make generated`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
